### PR TITLE
Fixed album icon for audioHmiState

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -156,6 +156,7 @@ dependencies {
     implementation "com.google.code.gson:gson:2.8.5"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.0.1"
     implementation "com.google.openlocationcode:openlocationcode:1.0.4"
+    implementation "ar.com.hjg:pngj:2.1.0"
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/PlaybackView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/PlaybackView.kt
@@ -5,6 +5,7 @@ import me.hufman.androidautoidrive.GraphicsHelpers
 import me.hufman.androidautoidrive.PhoneAppResources
 import me.hufman.androidautoidrive.TimeUtils.formatTime
 import me.hufman.androidautoidrive.UnicodeCleaner
+import me.hufman.androidautoidrive.Utils
 import me.hufman.androidautoidrive.carapp.RHMIModelMultiSetterData
 import me.hufman.androidautoidrive.carapp.RHMIModelMultiSetterInt
 import me.hufman.androidautoidrive.carapp.music.MusicImageIDs
@@ -51,6 +52,7 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 
 	val albumArtPlaceholderBig = carAppImages["${musicImageIDs.COVERART_LARGE}.png"]
 	val albumArtPlaceholderSmall = carAppImages["${musicImageIDs.COVERART_SMALL}.png"]
+	val grayscaleNoteIcon: Any
 
 	var displayedApp: MusicAppInfo? = null  // the app that was last redrawn
 	var displayedSong: MusicMetadata? = null    // the song  that was last redrawn
@@ -161,6 +163,14 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 			// repeat button is only available for Spotify (audioHmiState) due to lack of repeat button icon
 			repeatButton = null
 		}
+
+		// memoize grayscale note icon
+		val noteIcon = carAppImages["${musicImageIDs.SONG}.png"]
+		grayscaleNoteIcon = if (noteIcon != null) {
+			Utils.convertPngToGrayscale(noteIcon)
+		} else {
+			""
+		}
 	}
 
 	fun initWidgets(appSwitcherView: AppSwitcherView, enqueuedView: EnqueuedView, browseView: BrowseView, customActionsView: CustomActionsView) {
@@ -206,8 +216,14 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 		}
 		if (state is RHMIState.AudioHmiState) {
 			// weird that official Spotify doesn't need to do this
-			state.getArtistImageModel()?.asRaImageModel()?.value = carAppImages["${musicImageIDs.ARTIST}.png"]
-			state.getAlbumImageModel()?.asRaImageModel()?.value = carAppImages["${musicImageIDs.ALBUM}.png"]
+			val artistIcon = carAppImages["${musicImageIDs.ARTIST}.png"]
+			if (artistIcon != null) {
+				state.getArtistImageModel()?.asRaImageModel()?.value = Utils.convertPngToGrayscale(artistIcon)
+			}
+			val albumIcon = carAppImages["${musicImageIDs.ALBUM}.png"]
+			if (albumIcon != null) {
+				state.getAlbumImageModel()?.asRaImageModel()?.value = Utils.convertPngToGrayscale(albumIcon)
+			}
 
 			// setting the actions button icon since the button has a book icon by default
 			customActionButton.getImageModel()?.asImageIdModel()?.imageId = musicImageIDs.ACTIONS
@@ -300,7 +316,7 @@ class PlaybackView(val state: RHMIState, val controller: MusicController, val ca
 			val playlistModel = state.getPlayListModel()?.asRaListModel()
 			val playlist = RHMIModel.RaListModel.RHMIListConcrete(10)
 			playlist.addRow(PlaylistItem(false, skipBackEnabled, BMWRemoting.RHMIResourceIdentifier(BMWRemoting.RHMIResourceType.IMAGEID, musicImageIDs.SKIP_BACK), L.MUSIC_SKIP_PREVIOUS))
-			playlist.addRow(PlaylistItem(false, true, BMWRemoting.RHMIResourceIdentifier(BMWRemoting.RHMIResourceType.IMAGEID, musicImageIDs.SONG), title))
+			playlist.addRow(PlaylistItem(false, true, grayscaleNoteIcon, title))
 			playlist.addRow(PlaylistItem(false, skipNextEnabled, BMWRemoting.RHMIResourceIdentifier(BMWRemoting.RHMIResourceType.IMAGEID, musicImageIDs.SKIP_NEXT), L.MUSIC_SKIP_NEXT))
 			if (includeActions) {
 				playlistModel?.asRaListModel()?.setValue(playlist, 0, 3, 3)


### PR DESCRIPTION
I noticed that the audioHmiState album icon has a black background and doesn't have the appropriate system color (see before image) and after looking into the icon png file I noticed that the album icon has a RGB channel instead of the grayscale channel that the icon had in the older images.zip before the audioHmiState. It seems as though RGB encoded images are displayed as is in the iDrive system which is not what we want for this. Since the album icon image model in the audioHmiState is an RaImageModel I am storing an older grayscale version of the icon in the app resources and loading the raw ByteArray which behaves as expected when the image is displayed (see after image).

Before: 
![before](https://user-images.githubusercontent.com/11298573/95025367-df63af80-064e-11eb-9403-df884d3dc2a5.jpg)

After: 
![after](https://user-images.githubusercontent.com/11298573/95025370-e1c60980-064e-11eb-9804-a50172e9fb02.jpg)