### PR TITLE
Browse View Enhancements

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/MusicApp.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/MusicApp.kt
@@ -36,6 +36,7 @@ class MusicApp(val securityAccess: SecurityAccess, val carAppAssets: CarAppResou
 	var appListViewVisible = false
 	var playbackViewVisible = false
 	var enqueuedViewVisible = false
+	var browseViewVisible = false
 	val playbackView: PlaybackView
 	val appSwitcherView: AppSwitcherView
 	val enqueuedView: EnqueuedView
@@ -88,13 +89,16 @@ class MusicApp(val securityAccess: SecurityAccess, val carAppAssets: CarAppResou
 		playbackView = PlaybackView(playbackStates.removeFirst { PlaybackView.fits(it) }, musicController, carAppImages, phoneAppResources, graphicsHelpers, musicImageIDs)
 		appSwitcherView = AppSwitcherView(unclaimedStates.removeFirst { AppSwitcherView.fits(it) }, musicAppDiscovery, avContext, graphicsHelpers, musicImageIDs)
 		enqueuedView = EnqueuedView(unclaimedStates.removeFirst { EnqueuedView.fits(it) }, musicController, graphicsHelpers, musicImageIDs)
-		browseView = BrowseView(listOf(unclaimedStates.removeFirst { BrowseView.fits(it) }, unclaimedStates.removeFirst { BrowseView.fits(it) }), musicController, musicImageIDs)
+		browseView = BrowseView(listOf(unclaimedStates.removeFirst { BrowseView.fits(it) }, unclaimedStates.removeFirst { BrowseView.fits(it) }, unclaimedStates.removeFirst { BrowseView.fits(it) }), musicController, musicImageIDs, graphicsHelpers, this)
 		inputState = unclaimedStates.removeFirst { it.componentsList.filterIsInstance<RHMIComponent.Input>().firstOrNull()?.suggestModel ?: 0 > 0 }
 		customActionsView = CustomActionsView(unclaimedStates.removeFirst { CustomActionsView.fits(it) }, graphicsHelpers, musicController)
 
 		Log.i(TAG, "Selected state ${appSwitcherView.state.id} for App Switcher")
 		Log.i(TAG, "Selected state ${playbackView.state.id} for Playback")
 		Log.i(TAG, "Selected state ${enqueuedView.state.id} for Enqueued")
+		Log.i(TAG, "Selected state ${browseView.states[0].id} for Browse Page 1")
+		Log.i(TAG, "Selected state ${browseView.states[1].id} for Browse Page 2")
+		Log.i(TAG, "Selected state ${browseView.states[2].id} for Browse Page 3")
 		Log.i(TAG, "Selected state ${inputState.id} for Input")
 		Log.i(TAG, "Selected state ${customActionsView.state.id} for Custom Actions")
 
@@ -339,6 +343,10 @@ class MusicApp(val securityAccess: SecurityAccess, val carAppAssets: CarAppResou
 		if (enqueuedViewVisible) {
 			enqueuedView.redraw()
 		}
+		if (browseViewVisible) {
+			browseView.redraw()
+		}
+
 		// if running over USB or audio context is granted, set the global metadata
 		if (!musicAppMode.shouldRequestAudioContext() || avContext.currentContext) {
 			globalMetadata.redraw()

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowsePageView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowsePageView.kt
@@ -216,6 +216,7 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 		// redraw all currently visible rows if one of them has a cover art that was retrieved
 		for ((index, metadata) in visibleRowsOriginalMusicMetadata.withIndex()) {
 			if (metadata != visibleRows[index]) {
+				// can only see roughly 5 rows
 				showList(max(0, selectedIndex - 4), 8)
 				break
 			}

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowseView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowseView.kt
@@ -96,7 +96,15 @@ class BrowseView(val states: List<RHMIState>, val musicController: MusicControll
 	}
 
 	fun pushBrowsePage(directory: MusicMetadata?, stateId: Int? = null): BrowsePageView {
-		val nextState = states[pageStack.size % states.size]
+		val nextStateIndex = pageStack.size % states.size
+
+		// don't want the next state to be the original page state as the back action on original page state will exit to PlaybackView
+		val nextState = if (pageStack.size > 1 && nextStateIndex == 0) {
+			states[nextStateIndex+1]
+		} else {
+			states[nextStateIndex]
+		}
+
 		val state = states.firstOrNull { it.id == stateId } ?: nextState
 		val index = stack.indexOfLast { it.pageView != null } + 1 // what the next new index will be
 

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/EnqueuedView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/EnqueuedView.kt
@@ -14,7 +14,7 @@ import kotlin.math.max
 
 class EnqueuedView(val state: RHMIState, val musicController: MusicController, val graphicsHelpers: GraphicsHelpers, val musicImageIDs: MusicImageIDs) {
 	companion object {
-		//current default row width only supports 22 chars before rolling over
+		// current default row width only supports 22 chars before rolling over
 		private const val ROW_LINE_MAX_LENGTH = 22
 		private const val TITLE_MAX_LENGTH = 35
 

--- a/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
@@ -240,7 +240,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote): Musi
 			val item = recentlyPlayed?.items?.get(0)
 			if (item != null) {
 				remote.imagesApi.getImage(item.imageUri, Image.Dimension.THUMBNAIL).setResultCallback { coverArt ->
-					queueMetadata = QueueMetadata(item.title,item.subtitle,SpotifyMusicMetadata.createSpotifyMusicMetadataList(this, queueItems),coverArt)
+					queueMetadata = QueueMetadata(item.title,item.subtitle,queueItems,coverArt)
 				}
 			}
 		}
@@ -267,7 +267,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote): Musi
 		remote.contentApi.getChildrenOfItem(parentItem, 200, destination.size).setResultCallback { items ->
 			if (items != null && stillValid()) {    // this is still a valid request
 				destination.addAll(items.items.filterNotNull().map { listItem: ListItem ->
-					MusicMetadata.fromSpotifyQueueListItem(listItem)
+					SpotifyMusicMetadata.fromSpotifyQueueListItem(this, listItem)
 				})
 				if (destination.size < items.total && items.items.isNotEmpty()) {   // more tracks to load
 					loadPaginatedItems(destination, parentItem, stillValid, onComplete)
@@ -435,7 +435,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote): Musi
 		if (directory?.mediaId == null) {
 			remote.contentApi.getRecommendedContentItems("default-cars").setResultCallback { results ->
 				deferred.complete(results?.items?.map {
-					MusicMetadata.fromSpotify(it)
+					SpotifyMusicMetadata.fromBrowseItem(this, it)
 				} ?: LinkedList())
 			}.setErrorCallback {
 				deferred.complete(LinkedList())

--- a/app/src/main/java/me/hufman/androidautoidrive/phoneui/MusicBrowsePageFragment.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/phoneui/MusicBrowsePageFragment.kt
@@ -1,5 +1,6 @@
 package me.hufman.androidautoidrive.phoneui
 
+import android.app.Activity
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.graphics.Bitmap
@@ -46,6 +47,12 @@ class MusicBrowsePageFragment: Fragment(), CoroutineScope {
 	var loaderJob: Job? = null
 	val contents = ArrayList<MusicMetadata>()
 
+	fun onActive() {
+		musicController.listener = Runnable {
+			(this.context as Activity).listBrowse.adapter?.notifyDataSetChanged()
+		}
+	}
+
 	override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 		return inflater.inflate(R.layout.music_browsepage, container, false)
 	}
@@ -79,7 +86,7 @@ class MusicBrowsePageFragment: Fragment(), CoroutineScope {
 		browseDirectory(mediaId)
 	}
 
-	fun browseDirectory(mediaId: String?) {
+	private fun browseDirectory(mediaId: String?) {
 		txtEmpty.text = getString(R.string.MUSIC_BROWSE_LOADING)
 
 		if (loaderJob != null) {
@@ -131,10 +138,16 @@ class BrowseAdapter(val context: Context, val icons: Map<String, Bitmap>, val co
 		holder.view.findViewById<TextView>(R.id.txtBrowseEntrySubtitle).setText(item.subtitle)
 
 		holder.view.findViewById<ImageView>(R.id.imgBrowseType).colorFilter = Utils.getIconMask(context.getThemeColor(android.R.attr.textColorSecondary))
-		if (item.browseable) {
-			holder.view.findViewById<ImageView>(R.id.imgBrowseType).setImageBitmap(icons[MusicBrowsePageFragment.FOLDER_ID])
+
+		if(item.coverArt == null) {
+			holder.view.findViewById<ImageView>(R.id.imgBrowseType).setImageBitmap(
+					if (item.browseable)
+						icons[MusicBrowsePageFragment.FOLDER_ID]
+					else
+						icons[MusicBrowsePageFragment.SONG_ID]
+			)
 		} else {
-			holder.view.findViewById<ImageView>(R.id.imgBrowseType).setImageBitmap(icons[MusicBrowsePageFragment.SONG_ID])
+			holder.view.findViewById<ImageView>(R.id.imgBrowseType).setImageBitmap(item.coverArt)
 		}
 	}
 }

--- a/app/src/main/java/me/hufman/androidautoidrive/phoneui/MusicPlayerActivity.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/phoneui/MusicPlayerActivity.kt
@@ -59,6 +59,8 @@ class MusicPlayerActivity: AppCompatActivity() {
 			fun update(position: Int) {
 				if(position == 0) {
 					adapter.updateNowPlaying()
+				} else if (position == 1) {
+					adapter.updateBrowse()
 				} else if (position == 2) {
 					adapter.updateQueue()
 				}
@@ -121,6 +123,10 @@ class MusicPlayerPagerAdapter(fm: FragmentManager): FragmentStatePagerAdapter(fm
 
 	fun updateNowPlaying() {
 		(tabs["Now Playing"] as MusicNowPlayingFragment).onActive()
+	}
+
+	fun updateBrowse() {
+		((tabs["Browse"] as MusicBrowseFragment).fragment as MusicBrowsePageFragment).onActive()
 	}
 
 	fun updateQueue() {

--- a/app/src/main/res/layout/music_browse_listitem.xml
+++ b/app/src/main/res/layout/music_browse_listitem.xml
@@ -21,6 +21,7 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:orientation="vertical"
+        android:paddingLeft="6dp"
         android:paddingBottom="6dp">
 
         <TextView


### PR DESCRIPTION
With the [enqueued view enhancements rework](https://github.com/hufman/AndroidAutoIdrive/pull/128) came the system for displaying cover art for lazily loading cover art into a list view which I have extended to the "Browse" hmiState to enhance the presentation. The following features/fixes have been added: 
- Added the cover art for each of the browse items which are lazily loaded into the browse pages. If there is no cover art for the browse item then the song/folder icon will be displayed in its place
- Added a line to the browse items that displays additional information about the browse item if there is one present
- The back functionality will now be able to be used for when there are greater than 2 levels of pages (prior behavior would go back to the PlaybackView when the user tried to go back from a page that was greater than 2 levels, for example if the user went to "Your Library" -> "Playlists" and then back out of the "Playlists" browse page)
- Android app has been updated to show the cover art images where applicable otherwise falling back on the song/folder icon

BrowseView in action  (gif compression and frame rate are terrible to make it into a size that is attachable on github):
![newBrowseView](https://user-images.githubusercontent.com/11298573/97794860-4b452380-1bcd-11eb-99ed-e211810dec22.gif)

PhoneUI in action:
![browseViewPhoneUI](https://user-images.githubusercontent.com/11298573/97794784-29976c80-1bcc-11eb-8542-38a29ce34e14.jpg)

Also this PR should address this issue: https://github.com/hufman/AndroidAutoIdrive/issues/109