### PR TITLE
Removed whitelist on custom tab browsers to allow AppAuth to select appropriate browser instead

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/phoneui/SpotifyAuthorizationActivity.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/phoneui/SpotifyAuthorizationActivity.kt
@@ -19,8 +19,6 @@ import me.hufman.androidautoidrive.music.spotify.SpotifyWebApi
 import me.hufman.androidautoidrive.music.controllers.SpotifyAppController
 import me.hufman.androidautoidrive.music.spotify.SpotifyAuthStateManager
 import net.openid.appauth.*
-import net.openid.appauth.browser.BrowserWhitelist
-import net.openid.appauth.browser.VersionedBrowserMatcher
 import net.openid.appauth.connectivity.DefaultConnectionBuilder
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
@@ -163,9 +161,6 @@ class SpotifyAuthorizationActivity: Activity() {
 	private fun createAuthorizationService(): AuthorizationService {
 		Log.d(TAG, "Creating authorization service")
 		val builder = AppAuthConfiguration.Builder()
-		builder.setBrowserMatcher(BrowserWhitelist(
-				VersionedBrowserMatcher.CHROME_CUSTOM_TAB,
-				VersionedBrowserMatcher.SAMSUNG_CUSTOM_TAB))
 		builder.setConnectionBuilder(DefaultConnectionBuilder.INSTANCE)
 		return AuthorizationService(this, builder.build())
 	}


### PR DESCRIPTION
When the user doesn't have one of the whitelisted browsers, either Chrome or Samsung browser, and the user tried to authorize the Spotify Web API the app would crash with the following error:

```
java.lang.RuntimeException:` Unable to start activity ComponentInfo{me.hufman.androidautoidrive/me.hufman.androidautoidrive.phoneui.SpotifyAuthorizationActivity}: android.content.ActivityNotFoundException
...
Caused by: android.content.ActivityNotFoundException
...
```

As per [this](https://github.com/openid/AppAuth-Android#controlling-which-browser-is-used-for-authorization) documentation for AppAuth, I have removed the BrowserMatcher and instead will let the [AnyBrowserMatcher](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/browser/AnyBrowserMatcher.java) be used to match any browser the user has installed on their Android installation.