### PR TITLE
Added generic exception catch clause to catch other failures in SpotifyWebApi

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
@@ -85,7 +85,7 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 			Log.e(TAG, "Failed to get data from Liked Songs library due to authentication error with the message: ${e.message}")
 			authStateManager.addAccessTokenAuthorizationException(e)
 			createNotAuthorizedNotification()
-		} catch (e: SpotifyException) {
+		} catch (e: Exception) {
 			Log.e(TAG, "Exception occurred while getting Liked Songs library data with message: ${e.message}")
 		}
 		return null
@@ -140,6 +140,9 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 				authStateManager.addAccessTokenAuthorizationException(e)
 				createNotAuthorizedNotification()
 				null
+			} catch (e: Exception) {
+				Log.e(SpotifyAppController.TAG, "Failed to create the web API due to the error: ${e.message}")
+				null
 			}
 		} else {
 			val authorizationCode = authStateManager.getAuthorizationCode()
@@ -156,6 +159,9 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 				authStateManager.addAuthorizationCodeAuthorizationException(e)
 				Log.e(SpotifyAppController.TAG, "Failed to create the web API with an authorization code. Authorization failed with the error: ${e.message}")
 				createNotAuthorizedNotification()
+				null
+			} catch (e: Exception) {
+				Log.e(SpotifyAppController.TAG, "Failed to create the web API due to the error: ${e.message}")
 				null
 			}
 		}


### PR DESCRIPTION
This [issue](https://github.com/hufman/AndroidAutoIdrive/issues/195) made me realize that we have some potentially app crashing scenarios if the SpotifyWebApi class doesn't catch exceptions from other failures during API calls and client creation, such as a lack of an internet connection, that aren't of type SpotifyException.

Now instead of crashing in erroneous, recoverable scenarios such as the one described above, a log entry will be recording the error and a more appropriate flow will be followed.