### PR TITLE
Rearchitects BrowsePageView to use a real viewmodel

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowsePageView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowsePageView.kt
@@ -5,12 +5,8 @@ import de.bmw.idrive.BMWRemoting
 import kotlinx.coroutines.*
 import me.hufman.androidautoidrive.utils.GraphicsHelpers
 import me.hufman.androidautoidrive.UnicodeCleaner
-import me.hufman.androidautoidrive.utils.awaitPending
-import me.hufman.androidautoidrive.carapp.InputState
-import me.hufman.androidautoidrive.carapp.RHMIActionAbort
 import me.hufman.androidautoidrive.carapp.RHMIListAdapter
 import me.hufman.androidautoidrive.carapp.music.MusicImageIDs
-import me.hufman.androidautoidrive.music.MusicAction
 import me.hufman.androidautoidrive.music.MusicMetadata
 import me.hufman.androidautoidrive.utils.truncate
 import me.hufman.idriveconnectionkit.rhmi.*
@@ -28,7 +24,11 @@ enum class BrowseAction(val getLabel: () -> String) {
 		return getLabel()
 	}
 }
-class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val browsePageModel: BrowsePageModel, val browseController: BrowsePageController, var previouslySelected: MusicMetadata?, val graphicsHelpers: GraphicsHelpers): CoroutineScope {
+class BrowsePageView(val state: RHMIState,
+                     musicImageIDs: MusicImageIDs,
+                     val browsePageModel: BrowsePageModel,
+                     val browseController: BrowsePageController,
+                     val graphicsHelpers: GraphicsHelpers): CoroutineScope {
 	// a previous row that may have a checkmark
 	// remember to clear it when a new previouslySelected is set
 	var oldPreviouslySelectedIndex: Int? = null
@@ -73,15 +73,12 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 	}
 
 	private var loaderJob: Job? = null
-	private var searchJob: Job? = null
 	private var folderNameLabel: RHMIComponent.Label
 	private var actionsListComponent: RHMIComponent.List
 	private var musicListComponent: RHMIComponent.List
 
-	private var folder = browsePageModel.folder
 	private var musicList = ArrayList<MusicMetadata>()
 	private var currentListModel: RHMIModel.RaListModel.RHMIList = loadingList
-	private var shortcutSteps = 0
 
 	val checkmarkIcon = BMWRemoting.RHMIResourceIdentifier(BMWRemoting.RHMIResourceType.IMAGEID, musicImageIDs.CHECKMARK)
 	val folderIcon = BMWRemoting.RHMIResourceIdentifier(BMWRemoting.RHMIResourceType.IMAGEID, musicImageIDs.BROWSE)
@@ -118,11 +115,7 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 		hasSelectionChanged = false
 
 		// show the name of the directory
-		folderNameLabel.getModel()?.asRaDataModel()?.value = when (shortcutSteps) {
-			0 -> folder?.title ?: browsePageModel.musicAppInfo?.name ?: ""
-			1 -> "${browsePageModel.folder?.title ?: ""} / ${folder?.title ?: ""}"
-			else -> "${browsePageModel.folder?.title ?: ""} /../ ${folder?.title ?: ""}"
-		}
+		folderNameLabel.getModel()?.asRaDataModel()?.value = browsePageModel.title
 
 		// update the list whenever the car requests some more data
 		musicListComponent.requestDataCallback = RequestDataCallback { startIndex, numRows ->
@@ -137,7 +130,7 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 		showActionsList()
 
 		// show this page's previous list, if we are backing out to it and have wrapped the pages around
-		val index = max(0, musicList.indexOf(previouslySelected))   // redraw the checkmark item
+		val index = max(0, musicList.indexOf(browsePageModel.previouslySelected))   // redraw the checkmark item
 		showList(index, 1)
 		setFocusToPreviouslySelected()
 
@@ -153,15 +146,10 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 				currentListModel = loadingList
 				showList()
 			}
-			val musicListDeferred = browsePageModel.browseAsync(folder)
-			val musicList = musicListDeferred.awaitPending(LOADING_TIMEOUT) {
-				Log.d(TAG, "Browsing ${folder?.mediaId} timed out, retrying")
-				load()
-				delay(100)
-				return@launch
-			}
+			val musicListDeferred = browsePageModel.contents
+			val musicList = musicListDeferred.await()
 			this@BrowsePageView.musicList = ArrayList(musicList)
-			Log.d(TAG, "Browsing ${folder?.mediaId} resulted in ${musicList.count()} items")
+			Log.d(TAG, "Browsing ${browsePageModel.title} resulted in ${musicList.count()} items")
 
 			if (musicList.isEmpty()) {
 				currentListModel = emptyList
@@ -169,14 +157,12 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 			} else if (isSingleFolder(musicList)) {
 				// keep the loadingList in place
 				// navigate to the next deeper directory
-				folder = musicList.first { it.browseable }
-				shortcutSteps += 1
-				show()  // show the next page deeper
+				browseController.shortcutBrowsePage(musicList.first { it.browseable })
 				return@launch
 			} else {
 				currentListModel = object: RHMIListAdapter<MusicMetadata>(4, musicList) {
 					override fun convertRow(index: Int, item: MusicMetadata): Array<Any> {
-						val checkmarkIcon = if (previouslySelected == item) checkmarkIcon else ""
+						val checkmarkIcon = if (browsePageModel.previouslySelected == item) checkmarkIcon else ""
 						val coverArt = item.coverArt
 						val coverArtImage =
 								if (coverArt != null) {
@@ -248,14 +234,10 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 	private fun showActionsList() {
 		synchronized(actions) {
 			actions.clear()
-			if (browsePageModel.folder == null && (
-					browsePageModel.musicAppInfo?.searchable == true ||
-					browsePageModel.isSupportedAction(MusicAction.PLAY_FROM_SEARCH))) {
+			if (browsePageModel.showSearchAction) {
 				actions.add(BrowseAction.SEARCH)
 			}
-			if (browsePageModel.folder == null && browsePageModel.jumpbackFolder() != null) {
-				// the top of locationStack is always a single null element for the root
-				// we have previously browsed somewhere if locationStack.size > 1
+			if (browsePageModel.showJumpbackAction) {
 				actions.add(BrowseAction.JUMPBACK)
 			}
 			if (currentListModel != emptyList) {
@@ -274,7 +256,7 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 	private fun setFocusToPreviouslySelected() {
 		if (hasSelectionChanged) return     // user has changed selection
 		if (currentListModel == loadingList || currentListModel == emptyList) return    // not a valid music list
-		val previouslySelected = previouslySelected
+		val previouslySelected = browsePageModel.previouslySelected
 		if (previouslySelected != null) {
 			var index = musicList.indexOf(previouslySelected)
 			if (index < 0) {
@@ -304,99 +286,9 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 		}
 	}
 
-	private fun showFilterInput(inputState: RHMIState) {
-		object: InputState<MusicMetadata>(inputState) {
-			override fun onEntry(input: String) {
-				val suggestions = musicList.asSequence().filter {
-					UnicodeCleaner.clean(it.title ?: "").split(Regex("\\s+")).any { word ->
-						word.toLowerCase().startsWith(input.toLowerCase())
-					}
-				} + musicList.asSequence().filter {
-					UnicodeCleaner.clean(it.title?: "").toLowerCase().contains(input.toLowerCase())
-				}
-				sendSuggestions(suggestions.take(15).distinct().toList())
-			}
-
-			override fun onSelect(item: MusicMetadata, index: Int) {
-				previouslySelected = item  // update the selection state for future redraws
-				browseController.onListSelection(item, inputComponent.getSuggestAction()?.asHMIAction())
-			}
-
-			override fun convertRow(row: MusicMetadata): String {
-				return UnicodeCleaner.clean(row.title ?: "")
-			}
-		}
-	}
-
-	fun showSearchInput(inputState: RHMIState) {
-		object : InputState<MusicMetadata>(inputState) {
-			val SEARCHRESULT_SEARCHING = MusicMetadata(mediaId="__SEARCHING__", title=L.MUSIC_BROWSE_SEARCHING)
-			val SEARCHRESULT_EMPTY = MusicMetadata(mediaId="__EMPTY__", title=L.MUSIC_BROWSE_EMPTY)
-			val MAX_RETRIES = 2
-			var searchRetries = MAX_RETRIES
-
-			override fun onEntry(input: String) {
-				searchRetries = MAX_RETRIES
-				search(input)
-			}
-
-			fun search(input: String) {
-				if (input.length >= 2 && searchRetries > 0) {
-					searchJob?.cancel()
-					searchJob = launch(Dispatchers.IO) {
-						sendSuggestions(listOf(SEARCHRESULT_SEARCHING))
-						val suggestionsDeferred = browsePageModel.searchAsync(input)
-						val suggestions = suggestionsDeferred.awaitPending(LOADING_TIMEOUT) {
-							Log.d(TAG, "Searching ${browsePageModel.musicAppInfo?.name} for \"$input\" timed out, retrying")
-							searchRetries -= 1
-							search(input)
-							return@launch
-						}
-						sendSuggestions(suggestions ?: LinkedList())
-					}
-				} else if (input.length >= 2) {
-					// too many retries
-					sendSuggestions(listOf(SEARCHRESULT_EMPTY))
-				}
-			}
-
-			override fun sendSuggestions(newSuggestions: List<MusicMetadata>) {
-				val fullSuggestions = if (browsePageModel.isSupportedAction(MusicAction.PLAY_FROM_SEARCH)) {
-					listOf(BrowseView.SEARCHRESULT_PLAY_FROM_SEARCH) + newSuggestions
-				} else {
-					newSuggestions
-				}
-				super.sendSuggestions(fullSuggestions)
-			}
-
-			override fun onSelect(item: MusicMetadata, index: Int) {
-				if (item == SEARCHRESULT_EMPTY || item == SEARCHRESULT_SEARCHING) {
-					// invalid selection, don't change states
-					inputComponent.getSuggestAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = 0
-					throw RHMIActionAbort()
-				} else if (item == BrowseView.SEARCHRESULT_PLAY_FROM_SEARCH) {
-					browseController.playFromSearch(this.input)
-					browseController.onListSelection(item, inputComponent.getSuggestAction()?.asHMIAction())
-				} else {
-					previouslySelected = item  // update the selection state for future redraws
-					browseController.onListSelection(item, inputComponent.getSuggestAction()?.asHMIAction())
-				}
-			}
-
-			override fun convertRow(row: MusicMetadata): String {
-				return if (row.subtitle != null) {
-					UnicodeCleaner.clean("${row.title}\n${row.subtitle}")
-				} else {
-					UnicodeCleaner.clean(row.title ?: "")
-				}
-			}
-		}
-	}
-
 	fun hide() {
 		// cancel any loading
 		loaderJob?.cancel()
-		searchJob?.cancel()
 		musicListComponent.requestDataCallback = null
 
 		// clear any old checkmarks
@@ -404,18 +296,16 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 	}
 
 	private fun onActionCallback(index: Int, inputState: RHMIState) {
-		val action = actions.getOrNull(index)
-		when (action) {
+		when (actions.getOrNull(index)) {
 			BrowseAction.JUMPBACK -> {
 				browseController.jumpBack(musicListComponent.getAction()?.asHMIAction())
 			}
 			BrowseAction.FILTER -> {
 				musicListComponent.getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = inputState.id
-				showFilterInput(inputState)
+				browseController.openFilterInput(musicListComponent.getAction()?.asHMIAction(), browsePageModel)
 			}
 			BrowseAction.SEARCH -> {
-				musicListComponent.getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = inputState.id
-				showSearchInput(inputState)
+				browseController.openSearchInput(musicListComponent.getAction()?.asHMIAction())
 			}
 		}
 	}
@@ -429,11 +319,11 @@ class BrowsePageView(val state: RHMIState, val musicImageIDs: MusicImageIDs, val
 			Log.i(TAG,"User selected browse entry $entry")
 
 			// remember the previous checkmark to clear it
-			oldPreviouslySelectedIndex = musicList.indexOf(previouslySelected).let {
+			oldPreviouslySelectedIndex = musicList.indexOf(browsePageModel.previouslySelected).let {
 				if (it >= 0) it else null
 			}
-			previouslySelected = entry  // update the selection state for future redraws
-			browseController.onListSelection(entry, musicListComponent.getAction()?.asHMIAction())
+			browsePageModel.previouslySelected = entry  // update the selection state for future redraws
+			browseController.onListSelection(musicListComponent.getAction()?.asHMIAction(), entry)
 		} else {
 			Log.w(TAG, "User selected index $index but the list is only ${musicList.size} long")
 		}

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowseView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowseView.kt
@@ -15,7 +15,9 @@ import me.hufman.idriveconnectionkit.rhmi.RHMIState
 import java.util.*
 
 data class BrowseState(val location: MusicMetadata?,    // the directory the user selected
-                       var pageView: BrowsePageView? = null     // the PageView that is showing for this location
+                       var allLocations: MutableList<MusicMetadata?>,      // all locations, including any that were shortcutted
+                       var pageModel: BrowsePageModel? = null,      // the data to display in the BrowsePageView
+                       var pageView: BrowsePageView? = null,    // the PageView that is showing for this location
 )
 class BrowseView(val states: List<RHMIState>, val musicController: MusicController, val musicImageIDs: MusicImageIDs, val graphicsHelpers: GraphicsHelpers, val musicApp: MusicApp) {
 	companion object {
@@ -82,8 +84,8 @@ class BrowseView(val states: List<RHMIState>, val musicController: MusicControll
 		if (pageStack.isNotEmpty() && stateId != pageStack.last().state.id) {
 			// the system showed a page by the user pressing back, pop off the stack
 			stack.last { it.pageView != null}.apply {
-				this.pageView?.hide()
-				this.pageView = null
+				pageView?.hide()
+				pageView = null
 			}
 		}
 		// show the top of the stack if we popped off everything
@@ -127,14 +129,47 @@ class BrowseView(val states: List<RHMIState>, val musicController: MusicControll
 			// if we are in a different browse path, clear the remainder of the path
 			// and then add this current selection
 			stack.subList(index, stack.size).clear()
-			BrowseState(directory).apply { stack.add(this) }
+			BrowseState(directory, mutableListOf(directory)).also { stack.add(it) }
 		}
 
-		val browseModel = BrowsePageModel(this, musicController, directory)
-		val browsePage = BrowsePageView(state, musicImageIDs, browseModel, pageController, stack.getOrNull(index+1)?.location, graphicsHelpers)
+		// update the top page's model to declare it to be jumpable
+		// the top page isn't technically browseable, because null, so check for any deeper browseable
+		stack[0].pageModel?.showJumpbackAction = locationStack.any { it?.browseable == true }
+
+		// then push the next page's model
+		val title = BrowsePageModel.getTitle(musicController.currentAppInfo, stackSlot.allLocations)
+		val contents = musicController.browseAsync(stackSlot.allLocations.last())       // use any previously-shortcutted location
+		val previouslySelected = stack.getOrNull(index+1)?.location
+		val jumpable = false        // pushed pages are never browsable, we update the top page later
+		val searchable = directory == null && ((musicController.currentAppInfo?.searchable ?: false) || musicController.isSupportedAction(MusicAction.PLAY_FROM_SEARCH))
+		val browseModel = BrowsePageModel(title, contents, previouslySelected, jumpable, searchable)
+		val browsePage = BrowsePageView(state, musicImageIDs, browseModel, pageController, graphicsHelpers)
 		browsePage.initWidgets(inputState)
+		stackSlot.pageModel = browseModel
 		stackSlot.pageView = browsePage
 		return browsePage
+	}
+
+	fun shortcutBrowsePage(directory: MusicMetadata?) {
+		val browseState = stack.lastOrNull { it.location?.browseable != false } ?: return
+		browseState.allLocations.add(directory)
+		browseState.pageModel?.title = BrowsePageModel.getTitle(musicController.currentAppInfo, browseState.allLocations)
+		browseState.pageModel?.contents = musicController.browseAsync(directory)
+		browseState.pageView?.show()
+	}
+
+	fun openFilterInput(browsePageModel: BrowsePageModel): FilterInputView {
+		val nextState = FilterInputView(inputState, pageController, browsePageModel)
+		nextState.show()
+
+		return nextState
+	}
+
+	fun openSearchInput(): SearchInputView {
+		val nextState = SearchInputView(inputState, musicController, pageController)
+		nextState.show()
+
+		return nextState
 	}
 
 	fun playSong(song: MusicMetadata) {
@@ -143,8 +178,8 @@ class BrowseView(val states: List<RHMIState>, val musicController: MusicControll
 		stack.subList(index, stack.size).clear()
 
 		// remember the song as the last selected item
-		pageStack.last().previouslySelected = song
-		stack.add(BrowseState(song))
+		stack.last.pageModel?.previouslySelected = song
+		stack.add(BrowseState(song, mutableListOf(song)))
 
 		// now actually play
 		musicController.playSong(song)
@@ -162,35 +197,53 @@ class BrowseView(val states: List<RHMIState>, val musicController: MusicControll
 	}
 }
 
-class BrowsePageModel(private val browseView: BrowseView, private val musicController: MusicController, val folder: MusicMetadata?) {
-	val musicAppInfo: MusicAppInfo?
-		get() = musicController.currentAppInfo
-
-	fun isSupportedAction(action: MusicAction): Boolean {
-		return musicController.isSupportedAction(action)
-	}
-	fun jumpbackFolder(): MusicMetadata? {
-		return browseView.locationStack.lastOrNull { it?.browseable == true }
-	}
-	fun browseAsync(musicMetadata: MusicMetadata?): Deferred<List<MusicMetadata>> {
-		return musicController.browseAsync(musicMetadata)
-	}
-	fun searchAsync(query: String): Deferred<List<MusicMetadata>?> {
-		return musicController.searchAsync(query)
+data class BrowsePageModel(var title: String, var contents: Deferred<List<MusicMetadata>>,
+                           var previouslySelected: MusicMetadata?,
+                           var showJumpbackAction: Boolean, var showSearchAction: Boolean) {
+	companion object {
+		fun getTitle(appInfo: MusicAppInfo?, locations: List<MusicMetadata?>): String {
+			return when (locations.size) {
+				0 -> appInfo?.name ?: ""
+				1 -> locations.first()?.title ?: appInfo?.name ?: ""
+				2 -> "${locations.first()?.title ?: ""} / ${locations.last()?.title ?: ""}"
+				else -> "${locations.first()?.title ?: ""} /.. / ${locations.last()?.title ?: ""}"
+			}
+		}
 	}
 }
 
 class BrowsePageController(private val browseView: BrowseView, private val musicController: MusicController, private val playbackView: PlaybackView) {
+	/** Change the latest browse page to this directory, to shortcut through single-folder contents */
+	fun shortcutBrowsePage(directory: MusicMetadata?) {
+		browseView.shortcutBrowsePage(directory)
+	}
+
+	/** Push a new browse page with the deepest directory that was previously browse */
 	fun jumpBack(hmiAction: RHMIAction.HMIAction?) {
 		val nextPage = browseView.pushBrowsePage(browseView.locationStack.lastOrNull {it?.browseable == true})
 		hmiAction?.getTargetModel()?.asRaIntModel()?.value = nextPage.state.id
 	}
 
-	fun playFromSearch(search: String) {
-		musicController.playFromSearch(search)
+	/** Open the Filter Input screen */
+	fun openFilterInput(hmiAction: RHMIAction.HMIAction?, browsePageModel: BrowsePageModel) {
+		val nextState = browseView.openFilterInput(browsePageModel)
+		hmiAction?.getTargetModel()?.asRaIntModel()?.value = nextState.state.id
 	}
 
-	fun onListSelection(entry: MusicMetadata, hmiAction: RHMIAction.HMIAction?) {
+	/** Open the Search Input screen */
+	fun openSearchInput(hmiAction: RHMIAction.HMIAction?) {
+		val nextState = browseView.openSearchInput()
+		hmiAction?.getTargetModel()?.asRaIntModel()?.value = nextState.state.id
+	}
+
+	/** Call the musicController's playFromSearch command */
+	fun playFromSearch(hmiAction: RHMIAction.HMIAction?, search: String) {
+		musicController.playFromSearch(search)
+		hmiAction?.getTargetModel()?.asRaIntModel()?.value = playbackView.state.id
+	}
+
+	/** Push a browse page or play a song, and then update the given HMIAction's target state */
+	fun onListSelection(hmiAction: RHMIAction.HMIAction?, entry: MusicMetadata) {
 		if (entry.browseable) {
 			val nextPage = browseView.pushBrowsePage(entry)
 			hmiAction?.getTargetModel()?.asRaIntModel()?.value = nextPage.state.id

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/FilterInputView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/FilterInputView.kt
@@ -1,0 +1,85 @@
+package me.hufman.androidautoidrive.carapp.music.views
+
+import kotlinx.coroutines.*
+import me.hufman.androidautoidrive.UnicodeCleaner
+import me.hufman.androidautoidrive.carapp.InputState
+import me.hufman.androidautoidrive.carapp.RHMIActionAbort
+import me.hufman.androidautoidrive.music.MusicMetadata
+import me.hufman.idriveconnectionkit.rhmi.RHMIState
+import me.hufman.idriveconnectionkit.rhmi.VisibleCallback
+import java.util.*
+import kotlin.coroutines.CoroutineContext
+
+class FilterInputView(val state: RHMIState,
+                      private val browseController: BrowsePageController,
+                      private val browsePageModel: BrowsePageModel): CoroutineScope {
+	val FILTERRESULT_LOADING = MusicMetadata(mediaId="__LOADING__", title=L.MUSIC_BROWSE_LOADING)
+	val FILTERRESULT_EMPTY = MusicMetadata(mediaId="__EMPTY__", title=L.MUSIC_BROWSE_EMPTY)
+
+	override val coroutineContext: CoroutineContext
+		get() = Dispatchers.IO
+
+	var loadingJob: Job? = null
+	var musicList: List<MusicMetadata> = emptyList()
+	var inputState: InputState<MusicMetadata>? = null
+
+	fun show() {
+		// make sure the deferred contents are loaded
+		if (browsePageModel.contents.isCompleted) {
+			@Suppress("EXPERIMENTAL_API_USAGE")
+			musicList = browsePageModel.contents.getCompleted()
+		} else {
+			loadingJob = launch(Dispatchers.IO) {
+				musicList = browsePageModel.contents.await()
+				// update suggestions, if any input exists
+				inputState?.input?.also {
+					inputState?.onEntry(it)
+				}
+			}
+		}
+
+		// cancel any pending loading when hidden
+		state.visibleCallback = VisibleCallback { visible ->
+			if (!visible) loadingJob?.cancel()
+		}
+
+		// prepare the Input state
+		inputState = object: InputState<MusicMetadata>(state) {
+			override fun onEntry(input: String) {
+				if (!browsePageModel.contents.isCompleted) {
+					// still loading
+					sendSuggestions(listOf(FILTERRESULT_LOADING))
+				} else {
+					val suggestions = musicList.asSequence().filter {
+						UnicodeCleaner.clean(it.title ?: "").split(Regex("\\s+")).any { word ->
+							word.toLowerCase(Locale.ROOT).startsWith(input.toLowerCase(Locale.ROOT))
+						}
+					} + musicList.asSequence().filter {
+						UnicodeCleaner.clean(it.title
+								?: "").toLowerCase(Locale.ROOT).contains(input.toLowerCase(Locale.ROOT))
+					}
+					val results = suggestions.take(15).distinct().toList()
+					if (results.isEmpty()) {
+						sendSuggestions(listOf(FILTERRESULT_EMPTY))
+					} else {
+						sendSuggestions(results)
+					}
+				}
+			}
+
+			override fun onSelect(item: MusicMetadata, index: Int) {
+				if (item == FILTERRESULT_EMPTY || item == FILTERRESULT_LOADING) {
+					// invalid selection, don't change states
+					inputComponent.getSuggestAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = 0
+					throw RHMIActionAbort()
+				}
+				browsePageModel.previouslySelected = item  // update the selection state for future redraws
+				browseController.onListSelection(inputComponent.getSuggestAction()?.asHMIAction(), item)
+			}
+
+			override fun convertRow(row: MusicMetadata): String {
+				return UnicodeCleaner.clean(row.title ?: "")
+			}
+		}
+	}
+}

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/SearchInputView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/SearchInputView.kt
@@ -1,0 +1,92 @@
+package me.hufman.androidautoidrive.carapp.music.views
+
+import android.util.Log
+import kotlinx.coroutines.*
+import me.hufman.androidautoidrive.UnicodeCleaner
+import me.hufman.androidautoidrive.carapp.InputState
+import me.hufman.androidautoidrive.carapp.RHMIActionAbort
+import me.hufman.androidautoidrive.music.MusicAction
+import me.hufman.androidautoidrive.music.MusicController
+import me.hufman.androidautoidrive.music.MusicMetadata
+import me.hufman.androidautoidrive.utils.awaitPending
+import me.hufman.idriveconnectionkit.rhmi.RHMIState
+import me.hufman.idriveconnectionkit.rhmi.VisibleCallback
+import java.util.*
+import kotlin.coroutines.CoroutineContext
+
+class SearchInputView(val state: RHMIState,
+                      private val musicController: MusicController,
+                      private val browseController: BrowsePageController): CoroutineScope {
+	val SEARCHRESULT_SEARCHING = MusicMetadata(mediaId="__SEARCHING__", title=L.MUSIC_BROWSE_SEARCHING)
+	val SEARCHRESULT_EMPTY = MusicMetadata(mediaId="__EMPTY__", title=L.MUSIC_BROWSE_EMPTY)
+
+	override val coroutineContext: CoroutineContext
+		get() = Dispatchers.IO
+	private var searchJob: Job? = null
+
+	fun show() {
+		// cancel any pending loading when hidden
+		state.visibleCallback = VisibleCallback { visible ->
+			if (!visible) searchJob?.cancel()
+		}
+
+		object : InputState<MusicMetadata>(state) {
+			val MAX_RETRIES = 2
+			var searchRetries = MAX_RETRIES
+
+			override fun onEntry(input: String) {
+				searchRetries = MAX_RETRIES
+				search(input)
+			}
+
+			fun search(input: String) {
+				if (input.length >= 2 && searchRetries > 0) {
+					searchJob?.cancel()
+					searchJob = launch(Dispatchers.IO) {
+						sendSuggestions(listOf(SEARCHRESULT_SEARCHING))
+						val suggestionsDeferred = musicController.searchAsync(input)
+						val suggestions = suggestionsDeferred.awaitPending(BrowsePageView.LOADING_TIMEOUT) {
+							Log.d(TAG, "Searching ${musicController.currentAppInfo?.name} for \"$input\" timed out, retrying")
+							searchRetries -= 1
+							search(input)
+							return@launch
+						}
+						sendSuggestions(suggestions ?: LinkedList())
+					}
+				} else if (input.length >= 2) {
+					// too many retries
+					sendSuggestions(listOf(SEARCHRESULT_EMPTY))
+				}
+			}
+
+			override fun sendSuggestions(newSuggestions: List<MusicMetadata>) {
+				val fullSuggestions = if (musicController.isSupportedAction(MusicAction.PLAY_FROM_SEARCH)) {
+					listOf(BrowseView.SEARCHRESULT_PLAY_FROM_SEARCH) + newSuggestions
+				} else {
+					newSuggestions
+				}
+				super.sendSuggestions(fullSuggestions)
+			}
+
+			override fun onSelect(item: MusicMetadata, index: Int) {
+				if (item == SEARCHRESULT_EMPTY || item == SEARCHRESULT_SEARCHING) {
+					// invalid selection, don't change states
+					inputComponent.getSuggestAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = 0
+					throw RHMIActionAbort()
+				} else if (item == BrowseView.SEARCHRESULT_PLAY_FROM_SEARCH) {
+					browseController.playFromSearch(inputComponent.getSuggestAction()?.asHMIAction(), this.input)
+				} else {
+					browseController.onListSelection(inputComponent.getSuggestAction()?.asHMIAction(), item)
+				}
+			}
+
+			override fun convertRow(row: MusicMetadata): String {
+				return if (row.subtitle != null) {
+					UnicodeCleaner.clean("${row.title}\n${row.subtitle}")
+				} else {
+					UnicodeCleaner.clean(row.title ?: "")
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Rearchitects BrowsePageView to use a real viewmodel, to reduce the browse-specific logic in the BrowsePageView. This should help enable easier reuse for the search results in #199 
Also splits out the Filter/Search input pages to separate classes