### PR TITLE
BrowseView Bug Fixes and Tweaks

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowsePageView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowsePageView.kt
@@ -243,7 +243,7 @@ class BrowsePageView(val state: RHMIState,
 			if (browsePageModel.showJumpbackAction) {
 				actions.add(BrowseAction.JUMPBACK)
 			}
-			if (currentListModel != emptyList) {
+			if (browsePageModel.showFilterAction && currentListModel != emptyList) {
 				// show Filter entry while loading, until we know the list is empty
 				actions.add(BrowseAction.FILTER)
 			}

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowseView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/BrowseView.kt
@@ -148,7 +148,7 @@ class BrowseView(val states: List<RHMIState>, val musicController: MusicControll
 		val previouslySelected = stack.getOrNull(index+1)?.location
 		val jumpable = false        // pushed pages are never browsable, we update the top page later
 		val searchable = directory == null && ((musicController.currentAppInfo?.searchable ?: false) || musicController.isSupportedAction(MusicAction.PLAY_FROM_SEARCH))
-		val browseModel = BrowsePageModel(title, contents, previouslySelected, jumpable, searchable, false)
+		val browseModel = BrowsePageModel(title, contents, previouslySelected, jumpable, searchable, true, false)
 		val browsePage = BrowsePageView(state, musicImageIDs, browseModel, pageController, graphicsHelpers)
 		browsePage.initWidgets(inputState)
 		stackSlot.pageModel = browseModel
@@ -162,7 +162,7 @@ class BrowseView(val states: List<RHMIState>, val musicController: MusicControll
 
 		stack.subList(index, stack.size).clear()
 		val stackSlot = BrowseState(null, mutableListOf()).apply { stack.add(this) }
-		val browseModel = BrowsePageModel(L.MUSIC_SEARCH_RESULTS_LABEL, deferredSearchResults, null, false, true, true)
+		val browseModel = BrowsePageModel(L.MUSIC_SEARCH_RESULTS_LABEL, deferredSearchResults, null, false, false, false, true)
 		val browsePage = BrowsePageView(state, musicImageIDs, browseModel, pageController, graphicsHelpers)
 		browsePage.initWidgets(inputState)
 		stackSlot.pageModel = browseModel
@@ -219,7 +219,8 @@ class BrowseView(val states: List<RHMIState>, val musicController: MusicControll
 
 data class BrowsePageModel(var title: String, var contents: Deferred<List<MusicMetadata>?>,
                            var previouslySelected: MusicMetadata?,
-                           var showJumpbackAction: Boolean, var showSearchAction: Boolean, var isSearchResultView: Boolean) {
+                           var showJumpbackAction: Boolean, var showSearchAction: Boolean, var showFilterAction: Boolean,
+                           var isSearchResultView: Boolean) {
 	companion object {
 		fun getTitle(appInfo: MusicAppInfo?, locations: List<MusicMetadata?>): String {
 			return when (locations.size) {

--- a/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
@@ -518,8 +518,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 			}
 		} else {
 			loadPaginatedItems(directory.toListItem(), { !deferred.isCancelled }) {
-				val items = removeShufflePlayButtonMetadata(it)
-				deferred.complete(items)
+				deferred.complete(it)
 			}
 		}
 		return deferred.await()


### PR DESCRIPTION
With the recent Spotify search functionality I added the removal of the Shuffle Play button to the BrowseView contents along with a change to the way the Shuffle Play button is detected which introduced an issue which removed the currently playing playlist from the BrowseView. To remedy this and after further thought I removed the Shuffle Play button removal logic from the BrowseView. 

Also couple with this is the tweaking to the Search Result BrowseView page so the "Search" and "Filter" buttons will no longer be shown on the search result page. 