### PR TITLE
Spotify web api authorization stability enhancements

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/music/MusicAppDiscovery.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/MusicAppDiscovery.kt
@@ -247,7 +247,8 @@ class MusicAppDiscovery(val context: Context, val handler: Handler): CoroutineSc
 			Log.w(TAG, "Did not successfully create CombinedMusicAppController!")
 			return
 		}
-		controller.subscribe {
+
+		controller.onCreatedCallback {
 			Log.d(TAG, "Received update about controller probe ${appInfo.name}: connectable=${controller.isConnected()} pending=${controller.isPending()}")
 			appInfo.connectable = controller.isConnected()
 			appInfo.playsearchable = controller.isSupportedAction(MusicAction.PLAY_FROM_SEARCH)
@@ -261,11 +262,14 @@ class MusicAppDiscovery(val context: Context, val handler: Handler): CoroutineSc
 						appInfo.browseable = true
 						listener?.run()
 					}
+
 					val searchResults = controller.search("query")
+					Log.d(TAG, "Received search results from ${appInfo.name}")
 					if (searchResults?.isNotEmpty() == true) {
 						appInfo.searchable = true
 						listener?.run()
 					}
+
 					// save our cached version and stop probing
 					disconnectApp(appInfo)
 					appInfo.probed = true

--- a/app/src/main/java/me/hufman/androidautoidrive/music/controllers/CombinedMusicAppController.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/controllers/CombinedMusicAppController.kt
@@ -33,13 +33,16 @@ class CombinedMusicAppController(val controllers: List<Observable<out MusicAppCo
 	private var browseableController: MusicAppController? = null
 
 	var callback: ((MusicAppController) -> Unit)? = null
+	var onCreatedCallback: (() -> Unit)? = null
 
 	init {
 		controllers.forEach { pendingController ->
 			pendingController.subscribe { freshController ->
 				// a controller has connected/disconnected
 				if (freshController != null) {
+					onCreatedCallback?.invoke()
 					callback?.invoke(freshController)
+
 					freshController.subscribe { controller ->
 						// a controller wants to notify the UI
 						callback?.invoke(controller)
@@ -49,6 +52,12 @@ class CombinedMusicAppController(val controllers: List<Observable<out MusicAppCo
 		}
 	}
 
+	/**
+	 * Callback for when the controller is first created.
+	 */
+	fun onCreatedCallback(callback: () -> Unit) {
+		this.onCreatedCallback = callback
+	}
 
 	/**
 	 * Runs the given command against the first working of the connected controllers

--- a/app/src/main/java/me/hufman/androidautoidrive/music/controllers/MusicAppController.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/controllers/MusicAppController.kt
@@ -58,6 +58,7 @@ interface MusicAppController {
 	 * Returns whether the app is still connected
 	 */
 	fun isConnected(): Boolean
+
 	/**
 	 * Disconnects the app, and also clears out any subscribed callback
 	 */

--- a/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/controllers/SpotifyAppController.kt
@@ -81,7 +81,7 @@ class SpotifyAppController(context: Context, val remote: SpotifyAppRemote, val w
 		}
 
 		fun connect(): Observable<SpotifyAppController> {
-			Log.w(TAG, "Attempting to connect to Spotify Remote")
+			Log.i(TAG, "Attempting to connect to Spotify Remote")
 			val params = ConnectionParams.Builder(getClientId(context))
 					.setRedirectUri(REDIRECT_URI)
 					.showAuthView(prompt)

--- a/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/music/spotify/SpotifyWebApi.kt
@@ -90,6 +90,7 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 			Log.e(TAG, "Failed to get data from Liked Songs library due to authentication error with the message: ${e.message}")
 			authStateManager.addAccessTokenAuthorizationException(e)
 			createNotAuthorizedNotification()
+			webApi = null
 		} catch (e: Exception) {
 			Log.e(TAG, "Exception occurred while getting Liked Songs library data with message: ${e.message}")
 		}
@@ -168,6 +169,7 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 			Log.e(TAG, "Failed to get search results due to authentication error with the message: ${e.message}")
 			authStateManager.addAccessTokenAuthorizationException(e)
 			createNotAuthorizedNotification()
+			webApi = null
 		} catch (e: Exception) {
 			Log.e(TAG, "Exception occurred while attempting to get search results with the message: ${e.message}")
 		}
@@ -178,6 +180,9 @@ class SpotifyWebApi private constructor(val context: Context, val appSettings: M
 	 * Initializes the [SpotifyClientApi] instance and updates the [AuthState] with the token used.
 	 */
 	fun initializeWebApi(isProbing: Boolean = false) {
+		if(webApi != null) {
+			return
+		}
 		webApi = createWebApiClient()
 		if (webApi != null) {
 			authStateManager.updateTokenResponseWithToken(webApi!!.token, clientId)

--- a/app/src/test/java/me/hufman/androidautoidrive/music/SpotifyWebApiTest.kt
+++ b/app/src/test/java/me/hufman/androidautoidrive/music/SpotifyWebApiTest.kt
@@ -67,6 +67,17 @@ class SpotifyWebApiTest {
 	}
 
 	@Test
+	fun testInitializeWebApi_WebApiExisting()
+	{
+		val webApi: SpotifyClientApi = mock()
+		FieldSetter.setField(spotifyWebApi, spotifyWebApi::class.java.getDeclaredField("webApi"), webApi)
+
+		spotifyWebApi.initializeWebApi()
+
+		assertEquals(webApi, Whitebox.getInternalState(spotifyWebApi, "webApi"))
+	}
+
+	@Test
 	fun testInitializeWebApi_ValidAccessToken() = runBlocking {
 		val accessToken = "validAccessToken"
 		val expirationIn: Long = 5
@@ -572,6 +583,8 @@ class SpotifyWebApiTest {
 		verify(notificationManager, never()).notify(any(), any())
 
 		assertEquals(null, likedSongs)
+		val internalWebApi: SpotifyClientApi? = Whitebox.getInternalState(spotifyWebApi, "webApi")
+		assertNull(internalWebApi)
 	}
 
 	@Test
@@ -916,6 +929,9 @@ class SpotifyWebApiTest {
 		val searchResults = spotifyWebApi.searchForQuery(spotifyAppController, query)
 
 		assertTrue(searchResults.isEmpty())
+
+		val internalWebApi: SpotifyClientApi? = Whitebox.getInternalState(spotifyWebApi, "webApi")
+		assertNull(internalWebApi)
 
 		verify(spotifyAuthStateManager).addAccessTokenAuthorizationException(exception)
 		verify(notificationManager, never()).notify(any(), any())


### PR DESCRIPTION
The Spotify WebApi constantly needs authorization to be able to use it and with the addition of the search functionality the authorization time intervals has seemed to shorten quite a bit. While investigating into this to understand why it had to be reauthorized so frequency I recognized two major problems:

1. SpotifyWebApi#initializeWebApi() was creating a new webApi object every single time it was called, even when the webApi was already present. If it is present it means that it is authorized so this is unnecessary and increases the risk that the token is rejected from too many attempts to authorize with the same token.
2. the MusicAppDiscovery service was spamming the WebApi calls since when it is probing it is using the callbacks as when it should do the deeper level probing for searchability and browsability (spotify has 5-6 of these so that means 5-6 of these attempts) which was causing the Spotify service to revoke the token in some cases. I think Spotify has some sort of DDOS protection or something which revokes the token when there are too many simultaneous/continuous attempts to hit the endpoint.

By fixing these issues I've found that the authorization time intervals are much longer. I'll be continuing to monitor the authorization time intervals to see if they can be further improved on.