### PR TITLE
improve filtered search combining title and artist

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/FilterInputView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/FilterInputView.kt
@@ -62,7 +62,7 @@ class FilterInputView(val state: RHMIState,
 							} + it.filter { meta ->
 								meta.second.contains(inputLower)
 							}
-						}.take(15).map { it.first }.distinct().toList()
+						}.map { it.first }.distinct().take(15).toList()
 					}
 					if (results.isEmpty()) {
 						sendSuggestions(listOf(FILTERRESULT_EMPTY))

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/FilterInputView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/FilterInputView.kt
@@ -51,15 +51,19 @@ class FilterInputView(val state: RHMIState,
 					sendSuggestions(listOf(FILTERRESULT_LOADING))
 				} else {
 					val results = input.toLowerCase(Locale.ROOT).let { inputLower ->
-						musicList.asSequence().filter { meta ->
-							UnicodeCleaner.clean((meta.title ?: "") + " " + (meta.artist
-									?: "")).toLowerCase(Locale.ROOT).let {
-								it.split(Regex("\\s+")).any { word ->
+						musicList.asSequence().map {
+							Pair(it, UnicodeCleaner.clean((it.title ?: "") + " " + (it.artist
+									?: "")).toLowerCase(Locale.ROOT))
+						}.let {
+							it.filter { meta ->
+								meta.second.split(Regex("\\s+")).any { word ->
 									word.startsWith(inputLower)
-								} || it.contains(inputLower)
+								}
+							} + it.filter { meta ->
+								meta.second.contains(inputLower)
 							}
-						}
-					}.distinct().take(15).toList()
+						}.take(15).map { it.first }.distinct().toList()
+					}
 					if (results.isEmpty()) {
 						sendSuggestions(listOf(FILTERRESULT_EMPTY))
 					} else {

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/FilterInputView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/music/views/FilterInputView.kt
@@ -50,15 +50,16 @@ class FilterInputView(val state: RHMIState,
 					// still loading
 					sendSuggestions(listOf(FILTERRESULT_LOADING))
 				} else {
-					val suggestions = musicList.asSequence().filter {
-						UnicodeCleaner.clean(it.title ?: "").split(Regex("\\s+")).any { word ->
-							word.toLowerCase(Locale.ROOT).startsWith(input.toLowerCase(Locale.ROOT))
+					val results = input.toLowerCase(Locale.ROOT).let { inputLower ->
+						musicList.asSequence().filter { meta ->
+							UnicodeCleaner.clean((meta.title ?: "") + " " + (meta.artist
+									?: "")).toLowerCase(Locale.ROOT).let {
+								it.split(Regex("\\s+")).any { word ->
+									word.startsWith(inputLower)
+								} || it.contains(inputLower)
+							}
 						}
-					} + musicList.asSequence().filter {
-						UnicodeCleaner.clean(it.title
-								?: "").toLowerCase(Locale.ROOT).contains(input.toLowerCase(Locale.ROOT))
-					}
-					val results = suggestions.take(15).distinct().toList()
+					}.distinct().take(15).toList()
 					if (results.isEmpty()) {
 						sendSuggestions(listOf(FILTERRESULT_EMPTY))
 					} else {


### PR DESCRIPTION
In spotify when browsing the library you can go by artist, then you get individual titles but not the albums.
Or you go by album, then can filter by title. 
So far there is no way to filter your favorits for albums of a specific artist.

This change finds both the titles and the artists in the filtered view.