### PR TITLE
add readout-action to notification details view

### DIFF
--- a/app/src/main/java/me/hufman/androidautoidrive/L.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/L.kt
@@ -11,6 +11,7 @@ object L {
 	var NOTIFICATIONS_TITLE = "Notifications"
 	var NOTIFICATIONS_EMPTY_LIST = "No Notifications"
 	var NOTIFICATION_CLEAR_ACTION = "Clear"
+	var NOTIFICATION_READOUT_ACTION = "Speak"
 	var NOTIFICATION_OPTIONS = "Options"
 	var NOTIFICATION_POPUPS = "Notification Popups"
 	var NOTIFICATION_POPUPS_PASSENGER = "Popups with passenger"

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/ReadoutInteractions.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/ReadoutInteractions.kt
@@ -61,22 +61,18 @@ class ReadoutInteractions(val settings: NotificationSettings) {
 		}
 	}
 
-	fun triggerDisplayReadout(carNotification: CarNotification) {
-		if (settings.shouldReadoutNotificationDetails()) {
-			triggerReadout(carNotification)
-		}
-	}
-
-	fun triggerReadout(carNotification: CarNotification) {
-		if (carNotification != currentNotification) {
-			if (currentNotification != null) {
-				readoutController?.cancel()
-				Thread.sleep(500)
+	fun triggerDisplayReadout(carNotification: CarNotification, ignoreSetting: Boolean = false) {
+		if (ignoreSetting || settings.shouldReadoutNotificationDetails()) {
+			if (carNotification != currentNotification) {
+				if (currentNotification != null) {
+					readoutController?.cancel()
+					Thread.sleep(500)
+				}
+				currentNotification = carNotification
+				readoutController?.readout(carNotification.text.split("\n"))
+				// mark the tts state as busy, in case the Notification app checks the state before CDS updates
+				readoutController?.onTTSEvent(TTSState(ReadoutState.BUSY.value, -1, -1, readoutController?.name ?: "", null))
 			}
-			currentNotification = carNotification
-			readoutController?.readout(carNotification.text.split("\n"))
-			// mark the tts state as busy, in case the Notification app checks the state before CDS updates
-			readoutController?.onTTSEvent(TTSState(ReadoutState.BUSY.value, -1, -1, readoutController?.name ?: "", null))
 		}
 	}
 

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/ReadoutInteractions.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/ReadoutInteractions.kt
@@ -62,7 +62,13 @@ class ReadoutInteractions(val settings: NotificationSettings) {
 	}
 
 	fun triggerDisplayReadout(carNotification: CarNotification) {
-		if (settings.shouldReadoutNotificationDetails() && carNotification != currentNotification) {
+		if (settings.shouldReadoutNotificationDetails()) {
+			triggerReadout(carNotification)
+		}
+	}
+
+	fun triggerReadout(carNotification: CarNotification) {
+		if (carNotification != currentNotification) {
 			if (currentNotification != null) {
 				readoutController?.cancel()
 				Thread.sleep(500)

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/views/DetailsView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/views/DetailsView.kt
@@ -234,9 +234,9 @@ class DetailsView(val state: RHMIState, val phoneAppResources: PhoneAppResources
 			buttonIndex++
 		}
 		// enable any custom actions
-		(0..(5 - buttonIndex)).forEach { i ->
-			buttons[buttonIndex + i].apply {
-				notification.actions.getOrNull(i)?.also { action ->
+		buttons.subList(buttonIndex,5).forEachIndexed { index, button ->
+			button.apply {
+				notification.actions.getOrNull(index)?.also { action ->
 					setEnabled(true)
 					setSelectable(true)
 					getImageModel()?.asImageIdModel()?.imageId = 158

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/views/DetailsView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/views/DetailsView.kt
@@ -234,7 +234,7 @@ class DetailsView(val state: RHMIState, val phoneAppResources: PhoneAppResources
 			buttonIndex++
 		}
 		// enable any custom actions
-		buttons.subList(buttonIndex,5).forEachIndexed { index, button ->
+		buttons.subList(buttonIndex,6).forEachIndexed { index, button ->
 			button.apply {
 				notification.actions.getOrNull(index)?.also { action ->
 					setEnabled(true)

--- a/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/views/DetailsView.kt
+++ b/app/src/main/java/me/hufman/androidautoidrive/carapp/notifications/views/DetailsView.kt
@@ -33,7 +33,6 @@ class DetailsView(val state: RHMIState, val phoneAppResources: PhoneAppResources
 	val listWidget: RHMIComponent.List     // the widget to display the text
 	val imageWidget: RHMIComponent.Image
 	lateinit var inputView: RHMIState
-	lateinit var listView: NotificationListView
 
 	var visible = false
 	var selectedNotification: CarNotification? = null
@@ -50,7 +49,6 @@ class DetailsView(val state: RHMIState, val phoneAppResources: PhoneAppResources
 	fun initWidgets(listView: NotificationListView, inputState: RHMIState) {
 		state as RHMIState.ToolbarState
 		this.inputView = inputState
-		this.listView = listView
 
 		state.focusCallback = FocusCallback { focused ->
 			visible = focused
@@ -97,8 +95,6 @@ class DetailsView(val state: RHMIState, val phoneAppResources: PhoneAppResources
 			setEnabled(true)
 			setSelectable(true)
 		}
-
-		val buttons = ArrayList(state.toolbarComponentsList).filterIsInstance<RHMIComponent.ToolbarButton>().filter { it.action > 0}
 		state.toolbarComponentsList.forEach {
 			if (it.getAction() != null) {
 				it.setSelectable(false)
@@ -106,17 +102,6 @@ class DetailsView(val state: RHMIState, val phoneAppResources: PhoneAppResources
 				it.setVisible(true)
 			}
 		}
-		buttons[0].getImageModel()?.asImageIdModel()?.imageId = 150
-		buttons[0].setVisible(true)
-		buttons[0].setSelectable(true)
-		buttons.subList(1, 6).forEach {
-			it.getImageModel()?.asImageIdModel()?.imageId = 158
-		}
-		buttons.forEach {
-			// go back to the main list when an action is clicked
-			it.getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = listView.state.id
-		}
-
 		this.listState = listView.state
 	}
 
@@ -220,59 +205,59 @@ class DetailsView(val state: RHMIState, val phoneAppResources: PhoneAppResources
 
 		// find and enable the clear button
 		val buttons = ArrayList(state.toolbarComponentsList).filterIsInstance<RHMIComponent.ToolbarButton>().filter { it.action > 0}
-		val clearButton = buttons[0]
+		var buttonIndex = 0
 		if (notification.isClearable) {
-			clearButton.setEnabled(true)
-			clearButton.getTooltipModel()?.asRaDataModel()?.value = L.NOTIFICATION_CLEAR_ACTION
-			clearButton.getAction()?.asRAAction()?.rhmiActionCallback = RHMIActionButtonCallback {
-				controller.clear(notification.key)
-			}
-		} else {
-			clearButton.setEnabled(false)
-		}
-
-		val hasReadoutAction = !notificationSettings.shouldReadoutNotificationDetails()
-		val readoutButton = buttons[1]
-		if (hasReadoutAction) {
-			readoutButton.apply {
+			buttons[buttonIndex].apply {
 				setEnabled(true)
-				getTooltipModel()?.asRaDataModel()?.value = L.NOTIFICATION_READOUT_ACTION
+				setSelectable(true)
+				getImageModel()?.asImageIdModel()?.imageId = 150
+				getTooltipModel()?.asRaDataModel()?.value = L.NOTIFICATION_CLEAR_ACTION
 				getAction()?.asRAAction()?.rhmiActionCallback = RHMIActionButtonCallback {
-					getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = state.id
-					readoutInteractions.triggerReadout(notification)
+					controller.clear(notification.key)
+					getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = listState.id
 				}
 			}
-		} else {
-			readoutButton.apply {
-				setEnabled(false)
-				getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = listView.state.id
+			buttonIndex++
+		}
+		// add a readout-action in case automatic readout is not enabled
+		if (!notificationSettings.shouldReadoutNotificationDetails()) {
+			buttons[buttonIndex].apply {
+				setEnabled(true)
+				setSelectable(true)
+				getImageModel()?.asImageIdModel()?.imageId = 154
+				getTooltipModel()?.asRaDataModel()?.value = L.NOTIFICATION_READOUT_ACTION
+				getAction()?.asRAAction()?.rhmiActionCallback = RHMIActionButtonCallback {
+					readoutInteractions.triggerDisplayReadout(notification, ignoreSetting = true)
+					getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = state.id
+				}
 			}
+			buttonIndex++
 		}
 		// enable any custom actions
-		val offset = if (hasReadoutAction) 2 else 1
-		(if (hasReadoutAction) (0..3) else (0..4)).forEach {i ->
-			val action = notification.actions.getOrNull(i)
-			val button = buttons[offset+i]
-			if (action == null) {
-				button.setEnabled(false)
-				button.setSelectable(false)
-				button.getAction()?.asRAAction()?.rhmiActionCallback = null // don't leak memory
-			} else {
-				button.setEnabled(true)
-				button.setSelectable(true)
-				button.getTooltipModel()?.asRaDataModel()?.value = action.name.toString()
-				button.getAction()?.asRAAction()?.rhmiActionCallback = RHMIActionButtonCallback {
-					if (action.supportsReply ) {
-						// show input to reply
-						button.getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = inputView.id
-						val replyController = ReplyControllerNotification(notification, action, controller, notificationSettings.quickReplies)
-						ReplyView(listState, inputView, replyController)
-						readoutInteractions.cancel()
-					} else {
-						// trigger the custom action
-						controller.action(notification.key, action.name.toString())
-						button.getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = listState.id
+		(0..(5 - buttonIndex)).forEach { i ->
+			buttons[buttonIndex + i].apply {
+				notification.actions.getOrNull(i)?.also { action ->
+					setEnabled(true)
+					setSelectable(true)
+					getImageModel()?.asImageIdModel()?.imageId = 158
+					getTooltipModel()?.asRaDataModel()?.value = action.name.toString()
+					getAction()?.asRAAction()?.rhmiActionCallback = RHMIActionButtonCallback {
+						if (action.supportsReply) {
+							// show input to reply
+							getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = inputView.id
+							val replyController = ReplyControllerNotification(notification, action, controller, notificationSettings.quickReplies)
+							ReplyView(listState, inputView, replyController)
+							readoutInteractions.cancel()
+						} else {
+							// trigger the custom action
+							controller.action(notification.key, action.name.toString())
+							getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value = listState.id
+						}
 					}
+				} ?: run {
+					setEnabled(false)
+					setSelectable(false)
+					getAction()?.asRAAction()?.rhmiActionCallback = null // don't leak memory
 				}
 			}
 		}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -296,6 +296,7 @@
     <string name="NOTIFICATIONS_TITLE">Benachrichtigungen</string>
     <string name="NOTIFICATIONS_EMPTY_LIST">Keine Benachrichtigungen</string>
     <string name="NOTIFICATION_CLEAR_ACTION">Leeren</string>
+    <string name="NOTIFICATION_READOUT_ACTION">Vorlesen</string>
     <string name="NOTIFICATION_OPTIONS">Optionen</string>
     <string name="NOTIFICATION_POPUPS">PopUp-Benachrichtigung</string>
     <string name="NOTIFICATION_POPUPS_PASSENGER">PopUps mit Beifahrer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,6 +326,7 @@
     <string name="NOTIFICATIONS_TITLE">Notifications</string>
     <string name="NOTIFICATIONS_EMPTY_LIST">No Notifications</string>
     <string name="NOTIFICATION_CLEAR_ACTION">Clear</string>
+    <string name="NOTIFICATION_READOUT_ACTION">Speak</string>
     <string name="NOTIFICATION_OPTIONS">Options</string>
     <string name="NOTIFICATION_POPUPS">Notification Popups</string>
     <string name="NOTIFICATION_POPUPS_PASSENGER"> … with a passenger</string>

--- a/app/src/test/java/me/hufman/androidautoidrive/notifications/NotificationAppTest.kt
+++ b/app/src/test/java/me/hufman/androidautoidrive/notifications/NotificationAppTest.kt
@@ -149,9 +149,8 @@ class NotificationAppTest {
 			assertEquals("Richtext", visibleWidgets[3].asList()?.getModel()?.modelType)
 			assertEquals(true, mockServer.properties[visibleWidgets[3].id]?.get(RHMIProperty.PropertyId.SELECTABLE.id))
 			val state = app.viewDetails.state as RHMIState.ToolbarState
-			assertEquals( 150, state.toolbarComponentsList[1].getImageModel()?.asImageIdModel()?.imageId)
-			state.toolbarComponentsList.subList(2, 7).forEach {
-				assertEquals(158, it.getImageModel()?.asImageIdModel()?.imageId)
+			state.toolbarComponentsList.subList(1, 7).forEach {
+				assertEquals(true, it.properties[RHMIProperty.PropertyId.VISIBLE.id]?.value)
 			}
 		}
 		// test stateList setup
@@ -1174,15 +1173,17 @@ class NotificationAppTest {
 		assertEquals(true, buttons[0].properties[RHMIProperty.PropertyId.ENABLED.id]?.value)  // clear this notification button
 		assertEquals(true, buttons[0].properties[RHMIProperty.PropertyId.SELECTABLE.id]?.value)  // clear this notification button
 		assertEquals(true, buttons[0].properties[RHMIProperty.PropertyId.VISIBLE.id]?.value)
-		assertEquals(app.viewList.state.id, buttons[0].getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value)
+		assertEquals( 150, buttons[0].getImageModel()?.asImageIdModel()?.imageId)
 		assertEquals("Clear", buttons[0].getTooltipModel()?.asRaDataModel()?.value)  // clear this notification button
 		assertEquals(true, buttons[1].properties[RHMIProperty.PropertyId.ENABLED.id]?.value)
 		assertEquals(true, buttons[1].properties[RHMIProperty.PropertyId.SELECTABLE.id]?.value)
 		assertEquals(true, buttons[1].properties[RHMIProperty.PropertyId.VISIBLE.id]?.value)
+		assertEquals( 158, buttons[1].getImageModel()?.asImageIdModel()?.imageId)
 		assertEquals("Reply", buttons[1].getTooltipModel()?.asRaDataModel()?.value)  // reply button
 		assertEquals(true, buttons[2].properties[RHMIProperty.PropertyId.ENABLED.id]?.value)
 		assertEquals(true, buttons[2].properties[RHMIProperty.PropertyId.SELECTABLE.id]?.value)
 		assertEquals(true, buttons[2].properties[RHMIProperty.PropertyId.VISIBLE.id]?.value)
+		assertEquals( 158, buttons[2].getImageModel()?.asImageIdModel()?.imageId)
 		assertEquals("Mark Read", buttons[2].getTooltipModel()?.asRaDataModel()?.value)  // custom action button
 		assertEquals(false, buttons[3].properties[RHMIProperty.PropertyId.ENABLED.id]?.value)  // empty button
 		assertEquals(false, buttons[3].properties[RHMIProperty.PropertyId.SELECTABLE.id]?.value)
@@ -1193,6 +1194,8 @@ class NotificationAppTest {
 		assertEquals(app.viewList.state.id, buttons[2].getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value)
 		buttons[1].getAction()?.asRAAction()?.rhmiActionCallback?.onActionEvent(emptyMap<Int, Any>())
 		assertEquals(app.stateInput.id, buttons[1].getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value)
+		buttons[0].getAction()?.asRAAction()?.rhmiActionCallback?.onActionEvent(emptyMap<Int, Any>())
+		assertEquals(app.viewList.state.id, buttons[0].getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value)
 
 		val inputComponent = app.stateInput.componentsList[0] as RHMIComponent.Input
 
@@ -1227,6 +1230,56 @@ class NotificationAppTest {
 		assertEquals(listOf("Yes", "No", ":heart_eyes_cat:"), (mockServer.data[inputComponent.suggestModel] as BMWRemoting.RHMIDataTable).data.map { it[0] })
 		inputComponent.getSuggestAction()?.asRAAction()?.rhmiActionCallback?.onActionEvent(mapOf(1.toByte() to 0))
 		verify(carNotificationController).reply(notification.key, notification.actions[0].name.toString(), "Yes")
+	}
+
+	@Test
+	fun testActionReadout() {
+		val mockServer = MockBMWRemotingServer()
+		IDriveConnection.mockRemotingServer = mockServer
+		val app = PhoneNotifications(iDriveConnectionStatus, securityAccess, carAppResources, phoneAppResources, graphicsHelpers, carNotificationController, audioPlayer, notificationSettings)
+		app.readoutInteractions.readoutController = readoutController
+
+		whenever(notificationSettings.shouldReadoutNotificationDetails()) doReturn false
+
+		val actions = listOf(
+				CarNotification.Action("Mark Read", false, emptyList())
+		)
+		val notification = createNotificationObject("Title", "Title: Text\nTest",true, actions = actions)
+		NotificationsState.notifications.add(0, notification)
+		app.viewDetails.selectedNotification = notification
+		app.viewDetails.visible = true
+		app.viewDetails.show()
+
+		// verify the right buttons are enabled
+		val buttons = app.viewDetails.state.asToolbarState()!!.toolbarComponentsList.subList(1, 7)
+		assertEquals(true, buttons[0].properties[RHMIProperty.PropertyId.ENABLED.id]?.value)  // clear this notification button
+		assertEquals(true, buttons[0].properties[RHMIProperty.PropertyId.SELECTABLE.id]?.value)  // clear this notification button
+		assertEquals(true, buttons[0].properties[RHMIProperty.PropertyId.VISIBLE.id]?.value)
+		assertEquals( 150, buttons[0].getImageModel()?.asImageIdModel()?.imageId)
+		assertEquals("Clear", buttons[0].getTooltipModel()?.asRaDataModel()?.value)  // clear this notification button
+		assertEquals(true, buttons[1].properties[RHMIProperty.PropertyId.ENABLED.id]?.value)  // clear this notification button
+		assertEquals(true, buttons[1].properties[RHMIProperty.PropertyId.SELECTABLE.id]?.value)  // clear this notification button
+		assertEquals(true, buttons[1].properties[RHMIProperty.PropertyId.VISIBLE.id]?.value)
+		assertEquals( 154, buttons[1].getImageModel()?.asImageIdModel()?.imageId)
+		assertEquals("Speak", buttons[1].getTooltipModel()?.asRaDataModel()?.value)  // clear this notification button
+		assertEquals(true, buttons[2].properties[RHMIProperty.PropertyId.ENABLED.id]?.value)
+		assertEquals(true, buttons[2].properties[RHMIProperty.PropertyId.SELECTABLE.id]?.value)
+		assertEquals(true, buttons[2].properties[RHMIProperty.PropertyId.VISIBLE.id]?.value)
+		assertEquals( 158, buttons[2].getImageModel()?.asImageIdModel()?.imageId)
+		assertEquals("Mark Read", buttons[2].getTooltipModel()?.asRaDataModel()?.value)  // custom action button
+		assertEquals(false, buttons[3].properties[RHMIProperty.PropertyId.ENABLED.id]?.value)  // empty button
+		assertEquals(false, buttons[3].properties[RHMIProperty.PropertyId.SELECTABLE.id]?.value)
+		assertEquals(true, buttons[3].properties[RHMIProperty.PropertyId.VISIBLE.id]?.value)
+		assertEquals("", buttons[3].getTooltipModel()?.asRaDataModel()?.value)    // empty button
+
+		buttons[2].getAction()?.asRAAction()?.rhmiActionCallback?.onActionEvent(emptyMap<Int, Any>())
+		assertEquals(app.viewList.state.id, buttons[2].getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value)
+		buttons[1].getAction()?.asRAAction()?.rhmiActionCallback?.onActionEvent(emptyMap<Int, Any>())
+		assertEquals(app.viewDetails.state.id, buttons[1].getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value)
+		buttons[0].getAction()?.asRAAction()?.rhmiActionCallback?.onActionEvent(emptyMap<Int, Any>())
+		assertEquals(app.viewList.state.id, buttons[0].getAction()?.asHMIAction()?.getTargetModel()?.asRaIntModel()?.value)
+		// it should have start reading out the notification
+		verify(readoutController).readout(listOf("Title: Text", "Test"))
 	}
 
 	@Test


### PR DESCRIPTION
When viewing a notification in DetailsView there is no way to trigger readout if it is not enabled in the settings. If automatic readout is not enabled you have to go back from detailsview to the message-list to first enable it and then go back to the message to actually hear the readout. If you prefer not to have spoken messages but want to read out single messages every now and then this is uncomfortable and distracting.

This change dynamically adds an action to the details-view that allows to trigger readout if automatic readout is not enabled in the settings